### PR TITLE
Update RDX entry struct

### DIFF
--- a/RDBExplorer/Core/Formats/RDXReader.cs
+++ b/RDBExplorer/Core/Formats/RDXReader.cs
@@ -21,7 +21,8 @@ namespace RDBExplorer.Core.Formats
                     entries.Add(new RdxEntry
                     {
                         Index = reader.ReadUInt16(),
-                        Marker = reader.ReadUInt16(),
+                        SubdirIndex = reader.ReadByte(),
+                        LocaleIndex = reader.ReadByte(),
                         FileId = reader.ReadUInt32()
                     });
                 }

--- a/RDBExplorer/Core/Models/RdxEntry.cs
+++ b/RDBExplorer/Core/Models/RdxEntry.cs
@@ -3,7 +3,8 @@
     public struct RdxEntry
     {
         public ushort Index;
-        public ushort Marker;
+        public byte SubdirIndex; // if not 0xFF, path is {subdirs[subdirIndex]}/ instead of ./ (this is game dependent)
+        public byte LocaleIndex; // if not 0xFF, path is {selectedLanguage[localeIndex]}/0x{%08x}.fdata
         public uint FileId;
     }
 }


### PR DESCRIPTION
Not really used in Nioh 3 (I think, don't have the game) but is used in Atelier Yumia.

No logic to use this either, just to read it properly so someone else can implement a use case for it later.

SubdirIndex is used for DLC or "optional" installs. In Yumia this is `MountPoint_%d`.

LocaleIndex is dependent on the locale the game currently is in. Yumia for example has 2 locale types (Audio and Texture). The subdir in this case would be "enUS", "esES", etc.

Note, this is still read for external paths, for example instead of `./data/0x%08x.file` it ends up being `./MountPoint_1/enUS/data/0x%08.file` if both indices are set.